### PR TITLE
fix: change attribute name of open graph

### DIFF
--- a/theme.config.js
+++ b/theme.config.js
@@ -109,7 +109,7 @@ export default {
           }
         />
         <meta
-          name="og:description"
+          property="og:description"
           content={
             meta.description ||
             "SWR is a React Hooks library for data fetching. SWR first returns the data from cache (stale), then sends the fetch request (revalidate), and finally comes with the up-to-date data again."
@@ -119,12 +119,12 @@ export default {
         <meta name="twitter:site" content="@vercel" />
         <meta name="twitter:image" content={ogImage} />
         <meta
-          name="og:title"
+          property="og:title"
           content={
             title ? title + " – SWR" : "SWR: React Hooks for Data Fetching"
           }
         />
-        <meta name="og:image" content={ogImage} />
+        <meta property="og:image" content={ogImage} />
         <meta name="apple-mobile-web-app-title" content="SWR" />
       </>
     );


### PR DESCRIPTION
https://ogp.me/
https://developers.facebook.com/docs/sharing/webmasters https://developers.facebook.com/tools/debug/?q=https%3A%2F%2Fswr.vercel.app%2Fja%2Fdocs%2Fmutation

Following open graph protocol, use 'property' attribute


### Description

<!-- What're you changing? -->

- [ ] Adding new page
- [ ] Updating existing documentation
- [x] Other updates


